### PR TITLE
Add web dashboard and frontend scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ __pycache__/
 # OS-specific junk
 .DS_Store
 Thumbs.db
+
+# Node
+node_modules/
+**/node_modules/

--- a/README.md
+++ b/README.md
@@ -72,6 +72,25 @@ Want to contribute?
 - Create a feature branch
 - Submit a pull request
 
+### Running the API and Dashboard
+
+```bash
+uvicorn run_api:app --reload
+```
+
+Visit http://127.0.0.1:8000/ to view the Jinja2 dashboard which shows the current watchlist, alerts and trades.
+
+### Running the React Frontend
+
+A placeholder React app lives in `frontend/`. It can be replaced with a full create-react-app setup.
+
+```bash
+cd frontend
+npm start
+```
+
+The React app fetches data from the FastAPI endpoints `/watchlist`, `/alerts` and `/trades`.
+
 ---
 
 ## 📜 License

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "echo 'React placeholder. Run npx create-react-app frontend for full setup.'"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Wicksy Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="/src/index.js" type="module"></script>
+  </body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,22 @@
+import React, { useEffect, useState } from 'react';
+
+function App() {
+  const [watchlist, setWatchlist] = useState([]);
+  const [alerts, setAlerts] = useState([]);
+  const [trades, setTrades] = useState([]);
+
+  useEffect(() => {
+    fetch('/watchlist').then(res => res.json()).then(setWatchlist).catch(console.error);
+    fetch('/alerts').then(res => res.json()).then(setAlerts).catch(console.error);
+    fetch('/trades').then(res => res.json()).then(setTrades).catch(console.error);
+  }, []);
+
+  return (
+    <div>
+      <h1>Wicksy React Frontend</h1>
+      <pre>{JSON.stringify({ watchlist, alerts, trades }, null, 2)}</pre>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ aiosqlite>=0.19.0
 yfinance>=0.2.38
 requests>=2.31.0
 python-dotenv>=1.0.0
+fastapi>=0.110.0
+uvicorn>=0.27.0
+jinja2>=3.1.2

--- a/run_api.py
+++ b/run_api.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
+
+from wicksy.features import get_watchlist, get_alerts, get_trades
+from wicksy.web.dashboard import router as dashboard_router
+
+app = FastAPI()
+
+# Mount static files for the dashboard
+static_dir = Path(__file__).parent / "wicksy" / "web" / "static"
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+app.include_router(dashboard_router)
+
+
+@app.get("/watchlist")
+async def watchlist_endpoint():
+    return await get_watchlist()
+
+
+@app.get("/alerts")
+async def alerts_endpoint():
+    return await get_alerts()
+
+
+@app.get("/trades")
+async def trades_endpoint():
+    return await get_trades()

--- a/wicksy/features/__init__.py
+++ b/wicksy/features/__init__.py
@@ -1,0 +1,5 @@
+from .watchlist import get_watchlist
+from .alerts import get_alerts
+from .trades import get_trades
+
+__all__ = ["get_watchlist", "get_alerts", "get_trades"]

--- a/wicksy/features/alerts.py
+++ b/wicksy/features/alerts.py
@@ -451,3 +451,24 @@ async def alert_checker():
                     "DELETE FROM alerts WHERE id=?", [(i,) for i in to_delete]
                 )
                 await db.commit()
+
+
+async def get_alerts() -> list[dict]:
+    """Return all active alerts."""
+    await _ensure_schema()
+    async with aiosqlite.connect(DB_FILE) as db:
+        cur = await db.execute(
+            "SELECT id, user_id, symbol, target, direction, paused FROM alerts"
+        )
+        rows = await cur.fetchall()
+    return [
+        {
+            "id": row[0],
+            "user_id": row[1],
+            "symbol": row[2],
+            "target": row[3],
+            "direction": row[4],
+            "paused": bool(row[5]) if len(row) > 5 else False,
+        }
+        for row in rows
+    ]

--- a/wicksy/features/trades.py
+++ b/wicksy/features/trades.py
@@ -1,0 +1,23 @@
+import aiosqlite
+from wicksy.db import DB_FILE
+
+
+async def get_trades() -> list[dict]:
+    """Return all stored trades."""
+    async with aiosqlite.connect(DB_FILE) as db:
+        cur = await db.execute(
+            "SELECT id, user_id, symbol, entry, sl, tp, notes FROM trades"
+        )
+        rows = await cur.fetchall()
+    return [
+        {
+            "id": row[0],
+            "user_id": row[1],
+            "symbol": row[2],
+            "entry": row[3],
+            "sl": row[4],
+            "tp": row[5],
+            "notes": row[6],
+        }
+        for row in rows
+    ]

--- a/wicksy/features/watchlist.py
+++ b/wicksy/features/watchlist.py
@@ -226,3 +226,11 @@ async def updater():
     if not WATCHLIST_CHANNEL_ID or not BOT_INSTANCE:
         return
     await upsert_watchlist_message()
+
+
+async def get_watchlist() -> list[dict]:
+    """Return all symbols currently in the watchlist."""
+    async with aiosqlite.connect(DB_FILE) as db:
+        cur = await db.execute("SELECT symbol, type FROM watchlist")
+        rows = await cur.fetchall()
+    return [{"symbol": row[0], "type": row[1]} for row in rows]

--- a/wicksy/web/dashboard.py
+++ b/wicksy/web/dashboard.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from wicksy.features import get_watchlist, get_alerts, get_trades
+
+router = APIRouter()
+
+templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
+
+
+@router.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    watchlist = await get_watchlist()
+    alerts = await get_alerts()
+    trades = await get_trades()
+    return templates.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "watchlist": watchlist,
+            "alerts": alerts,
+            "trades": trades,
+        },
+    )

--- a/wicksy/web/static/style.css
+++ b/wicksy/web/static/style.css
@@ -1,0 +1,19 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 2rem;
+}
+
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-bottom: 2rem;
+}
+
+th, td {
+    border: 1px solid #ddd;
+    padding: 8px;
+}
+
+th {
+    background-color: #f4f4f4;
+}

--- a/wicksy/web/templates/index.html
+++ b/wicksy/web/templates/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Wicksy Dashboard</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>Wicksy Dashboard</h1>
+
+    <section>
+        <h2>Watchlist</h2>
+        <table>
+            <tr><th>Symbol</th><th>Type</th></tr>
+            {% for item in watchlist %}
+            <tr>
+                <td>{{ item.symbol }}</td>
+                <td>{{ item.type }}</td>
+            </tr>
+            {% else %}
+            <tr><td colspan="2">No entries</td></tr>
+            {% endfor %}
+        </table>
+    </section>
+
+    <section>
+        <h2>Alerts</h2>
+        <ul>
+            {% for alert in alerts %}
+            <li>{{ alert.symbol }} {{ alert.direction }} {{ alert.target }}</li>
+            {% else %}
+            <li>No alerts</li>
+            {% endfor %}
+        </ul>
+    </section>
+
+    <section>
+        <h2>Trades</h2>
+        <table>
+            <tr><th>Symbol</th><th>Entry</th><th>SL</th><th>TP</th><th>Notes</th></tr>
+            {% for trade in trades %}
+            <tr>
+                <td>{{ trade.symbol }}</td>
+                <td>{{ trade.entry }}</td>
+                <td>{{ trade.sl }}</td>
+                <td>{{ trade.tp }}</td>
+                <td>{{ trade.notes }}</td>
+            </tr>
+            {% else %}
+            <tr><td colspan="5">No trades</td></tr>
+            {% endfor %}
+        </table>
+    </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add FastAPI dashboard with Jinja2 templates for watchlist, alerts, and trades
- expose helper functions for reading watchlist, alerts, and trades from the database
- scaffold placeholder React frontend that fetches from API

## Testing
- `python -m pytest`
- `cd frontend && npm start`
- `timeout 2s uvicorn run_api:app` *(fails: command not found)*
- `pip install fastapi uvicorn jinja2` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b5368f9c832aa1bb4beb223e3197